### PR TITLE
Allow default behavior for ARM64 machines and skip high-memory VMs

### DIFF
--- a/lisa/tools/free.py
+++ b/lisa/tools/free.py
@@ -83,6 +83,9 @@ class Free(Tool):
     def get_free_memory_gb(self) -> int:
         return self._get_field_bytes_kib("Mem", "free") >> 20
 
+    def get_total_memory_gb(self) -> int:
+        return self._get_field_bytes_kib("Mem", "total") >> 20
+
     def get_total_memory(self) -> str:
         """
         Returns total memory in power of 1000 with unit

--- a/lisa/tools/kdump.py
+++ b/lisa/tools/kdump.py
@@ -663,7 +663,7 @@ class KdumpCBLMariner(KdumpBase):
                 "kdump will not work well on high memory Mariner-2.0 systems"
             )
 
-        # Update forc_rebuild before changing the dump path. Otherwise the default 
+        # Update forc_rebuild before changing the dump path. Otherwise the default
         # initrd will not honor the path
         kdump_conf = "/etc/kdump.conf"
         sed = self.node.tools[Sed]

--- a/lisa/tools/kdump.py
+++ b/lisa/tools/kdump.py
@@ -648,14 +648,13 @@ class KdumpCBLMariner(KdumpBase):
         """
         If the system memory size is bigger than 1T, the default size of /var/crash
         may not be enough to store the dump file, need to change the dump path
-        """
 
-        """
         path option is not supported by default initrd. Regenerated initrd will not
         boot properly in ARM64. So, skip the test if it is ARM64 and Mariner-2.0
         """
         if (
             self.node.os.information.version.major == 2
+            and isinstance(self.node.os, Posix)
             and self.node.os.get_kernel_information().hardware_platform == "aarch64"
         ):
             raise SkippedException(


### PR DESCRIPTION
Use `df` to get the available disk size instead of relying on capability.

Allow Mariner (both 2.0 and 3.0) to use the default kdump config options. Set `force_rebuild` only on high-mem machines where the crashdump path has to be updated.

Skip testing on high-mem machines for arm64 architecture. 